### PR TITLE
Use Coroutines+Flow instead of ApolloCall.Callback

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,6 +122,7 @@ dependencies {
 
     // GRAPHQL
     implementation Dependencies.graphql
+    implementation Dependencies.graphql_coroutines
 
     // GSON
     implementation Dependencies.gson

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -8,12 +8,12 @@ object Config {
 }
 
 object Versions {
-    val gradle_plugin_android           = "4.0.0-alpha03"
+    val gradle_plugin_android           = "4.0.0-alpha06"
     val gradle_plugin_google_services   = "4.3.3"
     val gradle_plugin_fabric            = "1.31.2"
 
     val java                            = JavaVersion.VERSION_1_8
-    val kotlin                          = "1.3.60-eap-25"
+    val kotlin                          = "1.3.61"
     val kotlin_coroutines               = "1.3.2"
 
     val android_material                = "1.2.0-alpha01"
@@ -32,7 +32,7 @@ object Versions {
     val crashlytics                     = "2.10.1"
     val dagger                          = "2.25.2"
     val glide                           = "4.10.0"
-    val graphql                         = "1.2.1"
+    val graphql                         = "1.2.2"
     val gson                            = "2.8.6"
     val leakcanary                      = "1.6.3"
     val okio                            = "2.2.2"
@@ -95,6 +95,7 @@ object Dependencies {
 
     // GRAPHQL
     val graphql = "com.apollographql.apollo:apollo-runtime:${Versions.graphql}"
+    val graphql_coroutines = "com.apollographql.apollo:apollo-coroutines-support:${Versions.graphql}"
 
     // GSON
     val gson = "com.google.code.gson:gson:${Versions.gson}"

--- a/features/business/build.gradle
+++ b/features/business/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 
     // GRAPHQL
     implementation Dependencies.graphql
+    implementation Dependencies.graphql_coroutines
 
     // GSON
     implementation Dependencies.gson

--- a/features/business/src/main/java/com/yelpexplorer/features/business/domain/repository/BusinessRepository.kt
+++ b/features/business/src/main/java/com/yelpexplorer/features/business/domain/repository/BusinessRepository.kt
@@ -1,10 +1,10 @@
 package com.yelpexplorer.features.business.domain.repository
 
-import androidx.lifecycle.LiveData
 import com.yelpexplorer.features.business.domain.model.Business
 import com.yelpexplorer.libraries.core.utils.Resource
+import kotlinx.coroutines.flow.Flow
 
 interface BusinessRepository {
-    suspend fun getBusinessList(term: String, location: String, sortBy: String, limit: Int): LiveData<Resource<List<Business>>>
-    suspend fun getBusinessDetails(businessId: String): LiveData<Resource<Business>>
+    suspend fun getBusinessList(term: String, location: String, sortBy: String, limit: Int): Flow<Resource<List<Business>>>
+    suspend fun getBusinessDetails(businessId: String): Flow<Resource<Business>>
 }

--- a/features/business/src/main/java/com/yelpexplorer/features/business/domain/usecase/GetBusinessDetailsUseCase.kt
+++ b/features/business/src/main/java/com/yelpexplorer/features/business/domain/usecase/GetBusinessDetailsUseCase.kt
@@ -1,16 +1,16 @@
 package com.yelpexplorer.features.business.domain.usecase
 
-import androidx.lifecycle.LiveData
 import com.yelpexplorer.features.business.domain.model.Business
 import com.yelpexplorer.features.business.domain.repository.BusinessRepository
 import com.yelpexplorer.libraries.core.utils.Resource
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetBusinessDetailsUseCase @Inject constructor(
     private val businessRepository: BusinessRepository
 ) {
 
-    suspend fun execute(businessId: String): LiveData<Resource<Business>> {
+    suspend fun execute(businessId: String): Flow<Resource<Business>> {
         return businessRepository.getBusinessDetails(businessId = businessId)
     }
 }

--- a/features/business/src/main/java/com/yelpexplorer/features/business/domain/usecase/GetBusinessListUseCase.kt
+++ b/features/business/src/main/java/com/yelpexplorer/features/business/domain/usecase/GetBusinessListUseCase.kt
@@ -1,16 +1,16 @@
 package com.yelpexplorer.features.business.domain.usecase
 
-import androidx.lifecycle.LiveData
 import com.yelpexplorer.features.business.domain.model.Business
 import com.yelpexplorer.features.business.domain.repository.BusinessRepository
 import com.yelpexplorer.libraries.core.utils.Resource
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetBusinessListUseCase @Inject constructor(
     private val businessRepository: BusinessRepository
 ) {
 
-    suspend fun execute(term: String, location: String, sortBy: String, limit: Int): LiveData<Resource<List<Business>>> {
+    suspend fun execute(term: String, location: String, sortBy: String, limit: Int): Flow<Resource<List<Business>>> {
         return businessRepository.getBusinessList(
             term = term,
             location = location,

--- a/features/business/src/main/java/com/yelpexplorer/features/business/presentation/businessdetails/BusinessDetailsViewModel.kt
+++ b/features/business/src/main/java/com/yelpexplorer/features/business/presentation/businessdetails/BusinessDetailsViewModel.kt
@@ -4,11 +4,13 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.liveData
 import androidx.lifecycle.map
 import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import com.yelpexplorer.features.business.R
+import com.yelpexplorer.features.business.domain.model.Business
 import com.yelpexplorer.features.business.domain.usecase.GetBusinessDetailsUseCase
 import com.yelpexplorer.libraries.core.utils.Resource
 import kotlinx.coroutines.Dispatchers
@@ -32,8 +34,10 @@ class BusinessDetailsViewModel @Inject constructor(
 
     init {
         _viewState = businessId.switchMap { businessId ->
-            liveData(context = viewModelScope.coroutineContext + Dispatchers.Main) {
-                emitSource(getBusinessDetailsUseCase.execute(businessId))
+            liveData<Resource<Business>>(context = viewModelScope.coroutineContext + Dispatchers.Main) {
+                emitSource(getBusinessDetailsUseCase.execute(
+                    businessId = businessId
+                ).asLiveData())
             }
         }.map { resource ->
             when (resource) {

--- a/features/business/src/main/java/com/yelpexplorer/features/business/presentation/businesslist/BusinessListViewModel.kt
+++ b/features/business/src/main/java/com/yelpexplorer/features/business/presentation/businesslist/BusinessListViewModel.kt
@@ -4,10 +4,12 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.liveData
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.yelpexplorer.features.business.R
+import com.yelpexplorer.features.business.domain.model.Business
 import com.yelpexplorer.features.business.domain.usecase.GetBusinessListUseCase
 import com.yelpexplorer.libraries.core.utils.Event
 import com.yelpexplorer.libraries.core.utils.Resource
@@ -37,13 +39,13 @@ class BusinessListViewModel @Inject constructor(
         get() = _viewState
 
     init {
-        _viewState = liveData(context = viewModelScope.coroutineContext + Dispatchers.Main) {
+        _viewState = liveData<Resource<List<Business>>>(context = viewModelScope.coroutineContext + Dispatchers.Main) {
             emitSource(getBusinessListUseCase.execute(
                 term = "sushi",
                 location = "montreal",
                 sortBy = "rating",
                 limit = 20
-            ))
+            ).asLiveData())
         }.map { resource ->
             when (resource) {
                 is Resource.Loading -> ViewState.ShowLoading(resource.data?.toBusinessListUiModel())

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Nov 02 09:15:56 EDT 2019
+#Thu Dec 19 22:49:40 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-milestone-3-all.zip


### PR DESCRIPTION
Added coroutine support for ApolloGraphQL
Replaced LiveData with Flow for everything after the ViewModels.

Resolves #7 

This is a first attempt at using Flow. There might be a better way of implementing it.